### PR TITLE
fix path & filename to save images on cloudinary

### DIFF
--- a/src/repository/images.py
+++ b/src/repository/images.py
@@ -1,4 +1,5 @@
 from typing import List
+import uuid
 from fastapi import File, HTTPException, UploadFile, status
 from sqlalchemy.orm import Session
 
@@ -40,8 +41,9 @@ async def create_images_post(description: str, hashtags: List[str], user: User, 
     for tag in tags_list:
         dbtag = await get_or_create_tag(db, tag)
         dbtags.append(dbtag)
-        
-    result = cloudinary.uploader.upload(file.file)
+
+    public_id = f'{settings.cloudinary_folder_name}/{uuid.uuid4()}'
+    result = cloudinary.uploader.upload(file.file, public_id=public_id)
     url = result['secure_url']
     qr_url = await get_qr_code_by_url(url)    
     images = Post(description=description, author_id=user.id, image_url=url, qr_code_url=qr_url, hashtags=dbtags)


### PR DESCRIPTION
Minor fix to provide more accurate filenaming (based on UUID) and path of the image file on cloudinary. After fix files will be saved in the project's folder instead the root. Project folder configured in .env as CLOUDINARY_FOLDER_NAME